### PR TITLE
Added tests up to 2D, got them passing - including tests for mixed BCs along a boundary

### DIFF
--- a/test/2D_bc_test.jl
+++ b/test/2D_bc_test.jl
@@ -1,0 +1,26 @@
+using LinearAlgebra, DiffEqOperators, Random, Test
+################################################################################
+# Test 2d extension
+################################################################################
+
+#Create Array
+n = 100
+m = 120
+A = rand(n,m)
+
+#Create atomic BC
+q1 = RobinBC([1.0, 2.0, 3.0], [0.0, -1.0, 2.0], [0.1, 0.1], 4.0)
+q2 = PeriodicBC{Float64}()
+
+BCx = vcat(fill(q1, div(m,2)), fill(q2, div(m,2)))  #The size of BCx has to be all size components *except* for x
+BCy = vcat(fill(q1, div(n,2)), fill(q2, div(n,2)))
+
+Q = MultiDimBC(BCx, BCy)
+
+Aextended = Q*A
+
+@test size(Aextended) == size(A).+2
+for i in 2:(n-1), j in 2:(m-1)
+    @test [Aextended[i, k] for k in 1:(m+2)] == Array(BCy[i-1]*A[i-1,:])
+    @test [Aextended[k, j] for k in 1:(n+2)] == Array(BCx[j-1]*A[:, j-1])
+end

--- a/test/boundary_padded_array.jl
+++ b/test/boundary_padded_array.jl
@@ -1,10 +1,20 @@
 using LinearAlgebra, DiffEqOperators, Random, Test
+################################################################################
+# Test BoundaryPaddedMatrix
+################################################################################
 
-A = rand(100,100)
+n = 100
+m = 120
+A = rand(n,m)
 A[1,1] = A[end,1] = A[1,end] = A[end,end] = 0.0
-lower = Vector(Vector{Float64}, A[1,2:(end-1)], transpose(A[2:(end-1),1]))
-upper = Vector(Vector{Float64}, A[end,2:(end-1)], transpose(A[2:(end-1),end]))
 
-Apad = DiffEqOperators.BoundaryPaddedMatrix{Float64, typeof(A), typeof(lower[1])}(lower, upper, A[2:(end-1), 2:(end-1)])
+lower = Vector[A[1,2:(end-1)], A[2:(end-1),1]]
+upper = Vector[A[end,2:(end-1)], A[2:(end-1),end]]
 
-@test A == Array(Apad)
+Apad = BoundaryPaddedMatrix{Float64, typeof(A), typeof(lower[1])}(lower, upper, A[2:(end-1), 2:(end-1)])
+
+@test A == Array(Apad) #test Concretization of BoundaryPaddedMatrix
+
+for i in 1:n, j in 1:m #test getindex for all indicies of Apad
+    @test A[i,j] == Apad[i,j]
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -9,6 +9,7 @@ import Base: isapprox
 @time @safetestset "Derivative Operators Interface" begin include("derivative_operators_interface.jl") end
 @time @safetestset "Validate and Compare Generic Operators" begin include("generic_operator_validation.jl") end
 @time @safetestset "Validate Boundary Padded Array Concretization" begin include("boundary_padded_array.jl") end
+@time @safetestset "Validate 2D Boundary Extension" begin include("2D_bc_test.jl") end
 
 #@time @safetestset "2nd order check" begin include("2nd_order_check.jl") end
 #@time @safetestset "KdV" begin include("KdV.jl") end # KdV times out and all fails


### PR DESCRIPTION
Another important point is that the type interface for AffineBC and its subtypes has been changed, wheras before it was AffineBC{T,V}, it is now AffineBC{T} because V was always a Vector{T}